### PR TITLE
Fix binary declaration for newer versions of yarn

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,11 +2,11 @@
   "name": "lastcall-artifact.sh",
   "license": "MIT",
   "files": [
-    "./artifact.sh"
+    "artifact.sh"
   ],
-  "bin": {
-    "artifact.sh": "./artifact.sh"
-  },
+  "bin": [
+    "artifact.sh"
+  ],
   "dependencies": {
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "lastcall-artifact.sh",
   "license": "MIT",
   "files": [
-    "artifact.sh"
+    "./artifact.sh"
   ],
   "bin": {
-    "artifact.sh": "artifact.sh"
+    "artifact.sh": "./artifact.sh"
   },
   "dependencies": {
   },


### PR DESCRIPTION
Having a key with a `.` in the bin object causes installation to fail in newer versions of yarn. This reverts back to using an array instead of an object for the bin property.