### PR TITLE
switch back to object for binary property

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "files": [
     "artifact.sh"
   ],
-  "bin": [
-    "artifact.sh"
-  ],
+  "bin": {
+    "artifact.sh": "artifact.sh"
+  },
   "dependencies": {
   },
   "devDependencies": {


### PR DESCRIPTION
Changing the binary property to an array caused warnings about an invalid binary to go away, but did not actually cause the binary file to get added to `$DIR/node_modules/.bin` when using yarn