### PR TITLE
Add test to show that any default branch name can be used

### DIFF
--- a/tests/artifact-test.bats
+++ b/tests/artifact-test.bats
@@ -19,13 +19,13 @@ setup() {
     srcrepo="${BATS_TEST_TMPDIR}/src"
     artifactrepo="${BATS_TEST_TMPDIR}/artifact"
     workspace="${BATS_TEST_TMPDIR}/ws"
-    branchname="artifact_branch_main"
+    mainbranchname="artifact_branch_main"
 
     load test_helper
     load ../node_modules/bats-support/load
     load ../node_modules/bats-assert/load
-    setup_source_repo "$srcrepo" "$branchname"
-    setup_artifact_repo "$artifactrepo" "$branchname"
+    setup_source_repo "$srcrepo" "$mainbranchname"
+    setup_artifact_repo "$artifactrepo" "$mainbranchname"
     mkdir -p "$workspace" && git clone "$srcrepo" "$workspace" > /dev/null 2>&1
     cd "$workspace"
 }
@@ -139,7 +139,8 @@ teardown() {
 }
 
 @test "it uses the default branch from the git remote" {
+  git checkout -b mybranch
   run $artifact -a "$artifactrepo"
   assert_success
-  assert_output --partial "Detected existing $branchname branch. Starting from here."
+  assert_output --partial "The mybranch branch doesn't exist yet. Starting from $mainbranchname"
 }

--- a/tests/artifact-test.bats
+++ b/tests/artifact-test.bats
@@ -19,12 +19,13 @@ setup() {
     srcrepo="${BATS_TEST_TMPDIR}/src"
     artifactrepo="${BATS_TEST_TMPDIR}/artifact"
     workspace="${BATS_TEST_TMPDIR}/ws"
+    branchname="artifact_branch_main"
 
     load test_helper
     load ../node_modules/bats-support/load
     load ../node_modules/bats-assert/load
-    setup_source_repo "$srcrepo"
-    setup_artifact_repo "$artifactrepo"
+    setup_source_repo "$srcrepo" "$branchname"
+    setup_artifact_repo "$artifactrepo" "$branchname"
     mkdir -p "$workspace" && git clone "$srcrepo" "$workspace" > /dev/null 2>&1
     cd "$workspace"
 }
@@ -135,4 +136,10 @@ teardown() {
   run $artifact -a "$artifactrepo"
   assert_success
   git --git-dir="$artifactrepo" show --quiet --format=%B | assert_output --partial "Initial commit on source" -
+}
+
+@test "it uses the default branch from the git remote" {
+  run $artifact -a "$artifactrepo"
+  assert_success
+  assert_output --partial "Detected existing $branchname branch. Starting from here."
 }

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 function setup_source_repo() {
-  setup_repo "$1-working"
+  setup_repo "$1-working" $2
   mkdir nested
   echo "source" > source.txt
   echo "/source-ignored.txt" | tee .gitignore nested/.gitignore
@@ -12,7 +12,7 @@ function setup_source_repo() {
 }
 
 function setup_artifact_repo() {
-  setup_repo "$1-working"
+  setup_repo "$1-working" $2
   echo "artifact" > artifact.txt
   git add . && git commit -m "Initial commit on artifact"
   mv "$1-working/.git" "$1" && rm -rf "$1-working"
@@ -20,5 +20,7 @@ function setup_artifact_repo() {
 }
 
 function setup_repo() {
-  mkdir -p $1 && cd $1 && git init
+
+  mkdir -p $1 && cd $1 && git init --initial-branch="$2"
+
 }

--- a/tests/test_helper.bash
+++ b/tests/test_helper.bash
@@ -20,7 +20,5 @@ function setup_artifact_repo() {
 }
 
 function setup_repo() {
-
   mkdir -p $1 && cd $1 && git init --initial-branch="$2"
-
 }


### PR DESCRIPTION
#5 switches artifactsh script to use the git remote default branch. This sets the default branch to `artifact_branch_main` for the tests, and verifies that that branch is used when starting a new branch in the downstream